### PR TITLE
.standout-link and .standout-link:hover don't use colours from _colour-assignment.scss and :hover is the same as the normal

### DIFF
--- a/web/css/default.css
+++ b/web/css/default.css
@@ -289,8 +289,8 @@ h1, h2 { font-weight: normal; }
 .title-bold { font-weight: bold; }
 
 /** A link that stands out */
-.standout-link { color: #ff6500; font-weight: bold; text-decoration: none; }
-.standout-link:hover { color: #ff6500 / 1.1; }
+.standout-link { color: #e28c05; font-weight: bold; text-decoration: none; }
+.standout-link:hover { color: #cd7f04; }
 
 /* Remove default fieldset styles. */
 fieldset { border: 0; margin: 0 0 2.5em 0; padding: 0; }

--- a/web/sass/base/_typography.scss
+++ b/web/sass/base/_typography.scss
@@ -81,10 +81,10 @@ h1, h2 { font-weight: normal; }
  * A link that stands out
  */
 .standout-link {
-    color: #ff6500;
+    color: $c-standout-link-color;
     font-weight: bold;
     text-decoration: none;
     &:hover {
-        color: #ff6500 / 1.1;
+        color: $c-standout-link-hover-color;
     }
 }


### PR DESCRIPTION
I think it's a bug here https://github.com/mysociety/citizenconnect/blob/master/web/sass/base/_typography.scss#L83-L90 because it should be using colors from here: https://github.com/mysociety/citizenconnect/blob/master/web/sass/theme-config/default/_colour-assignment.scss#L53-L54
