### PR TITLE
Add 'escalated' symbol (or simple icon) to public problem pages

### DIFF
--- a/issues/templates/issues/issue_detail.html
+++ b/issues/templates/issues/issue_detail.html
@@ -32,6 +32,9 @@
                         {{ object.get_commissioned_display }},&nbsp;
                     {% endif %}
                 {% endif %}
+                {% if object.status == object.ESCALATED %}
+                  <span class="icon-warning"></span>
+                {% endif %}
                 {{ object.get_status_display }}
             </p>
 


### PR DESCRIPTION
i.e. pages like: http://citizenconnect.staging.mysociety.org/choices/problem/24018
