### PR TITLE
Review submission form doesn't allow for the fact that the submitted visit date is always the first of the month

### DIFF
--- a/reviews_submit/forms.py
+++ b/reviews_submit/forms.py
@@ -28,11 +28,15 @@ class ReviewForm(forms.ModelForm):
         month_year_of_visit = self.cleaned_data['month_year_of_visit']
         if month_year_of_visit > datetime.date.today():
             raise forms.ValidationError("The month and year of visit can't be in the future")
-        oldest_permittable = datetime.date.today() - datetime.timedelta(days=settings.NHS_CHOICES_API_MAX_REVIEW_AGE_IN_DAYS)
-        if month_year_of_visit < oldest_permittable:
-            raise forms.ValidationError("The month and year of visit can't be more than two years ago")
-        return month_year_of_visit
 
+        # Check that the review date is not too long ago. Compare the year and
+        # month seperately as we can't be sure about the day as we don't capture
+        # it.
+        oldest_permittable = datetime.date.today() - datetime.timedelta(days=settings.NHS_CHOICES_API_MAX_REVIEW_AGE_IN_DAYS)
+        if self._mm_yyyy_lt_compare_dates(month_year_of_visit, oldest_permittable):
+            raise forms.ValidationError("The month and year of visit can't be more than two years ago")
+
+        return month_year_of_visit
 
     @classmethod
     def _mm_yyyy_lt_compare_dates(cls, dt_a, dt_b ):

--- a/reviews_submit/tests.py
+++ b/reviews_submit/tests.py
@@ -174,11 +174,19 @@ class ReviewFormViewTest(ReviewFormViewBase, TestCase):
         # For some reason, assertFormError doesn't like this error
         self.assertContains(resp, "The month and year of visit can&#39;t be in the future")
 
+    def test_submitting_a_review_with_a_just_long_enough_ago_date(self):
+        self.assertEquals(self.organisation.submitted_reviews.count(), 0)
+        past_date = datetime.datetime.now() - datetime.timedelta(days=settings.NHS_CHOICES_API_MAX_REVIEW_AGE_IN_DAYS)
+        self.review_post_data['month_year_of_visit_year'] = past_date.year
+        self.review_post_data['month_year_of_visit_month'] = past_date.month
+        resp = self.client.post(self.review_form_url, self.review_post_data)
+        self.assert_review_correctly_stored()
+
     def test_submitting_a_review_with_a_too_long_ago_date(self):
         self.assertEquals(self.organisation.submitted_reviews.count(), 0)
-        past_date = datetime.datetime.now() - datetime.timedelta(days=settings.NHS_CHOICES_API_MAX_REVIEW_AGE_IN_DAYS + 20)
-        self.review_post_data['month_year_of_visit_year'] = str(past_date.year)
-        self.review_post_data['month_year_of_visit_month'] = str(past_date.month)
+        past_date = datetime.datetime.now() - datetime.timedelta(days=settings.NHS_CHOICES_API_MAX_REVIEW_AGE_IN_DAYS) - datetime.timedelta(days=31)
+        self.review_post_data['month_year_of_visit_year'] = past_date.year
+        self.review_post_data['month_year_of_visit_month'] = past_date.month
         resp = self.client.post(self.review_form_url, self.review_post_data)
         self.assertEquals(self.organisation.submitted_reviews.count(), 0)
         # For some reason, assertFormError doesn't like this error


### PR DESCRIPTION
If I submit a form in May, and select May 2011 as when I visited, I should be allowed to post my review (it _could_ be within two years), but unless today is the 1st, I won't be allowed to. 

Here's the culprit: https://github.com/mysociety/citizenconnect/blob/master/reviews_submit/forms.py#L31-L32
