### PR TITLE
Change to Django 1.4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ pytz
 lxml==3.2.1
 
 ### Django related
-Django==1.4.3
+Django==1.4.5
 South
 django-pagination
 django-tables2
-django-reversion==1.6.5  # compatible with Django 1.4.3
+django-reversion==1.6.6  # compatible with Django 1.4.5
 django-concurrency
 django-dirtyfields==0.1  # see issues.models.Problems.save for reason it is pinned
 django-passwords


### PR DESCRIPTION
Currently we're pinned to 1.4.3 in `requirements.txt`.

We should up to 1.4.5 for security reasons: https://www.djangoproject.com/weblog/2013/feb/19/security/

Note that there are some changes listed there that we should deal with if they affect us.
