### PR TITLE
can enter incorrect emails and phone no's

### DIFF
--- a/issues/forms.py
+++ b/issues/forms.py
@@ -110,6 +110,17 @@ class ProblemForm(forms.ModelForm):
         return reporter_phone        
 
 
+    def clean_preferred_contact_method(self):
+        # Check that if they prefer to be contacted by phone, they actually provided a number
+        reporter_phone = self.cleaned_data.get('reporter_phone')
+        preferred_contact_method = self.cleaned_data.get('preferred_contact_method')
+
+        # call this method, which will raise ValidationError if it fails
+        Problem.validate_preferred_contact_method_and_reporter_phone(preferred_contact_method, reporter_phone)
+
+        return preferred_contact_method
+
+
     class Meta:
         model = Problem
 

--- a/issues/models.py
+++ b/issues/models.py
@@ -336,8 +336,13 @@ class Problem(dirtyfields.DirtyFieldsMixin, AuditedModel):
         Custom model validation
         """
         super(Problem, self).clean()
+        self.validate_preferred_contact_method_and_reporter_phone(self.preferred_contact_method, self.reporter_phone)
+
+    @classmethod
+    def validate_preferred_contact_method_and_reporter_phone(cls, preferred_contact_method, reporter_phone):
         # Check that if they prefer to be contacted by phone, they actually provided a number
-        if self.preferred_contact_method == self.CONTACT_PHONE and not self.reporter_phone:
+        # this is a separate method so we can call if from form easily to share error message
+        if preferred_contact_method == cls.CONTACT_PHONE and not reporter_phone:
             raise ValidationError('You must provide a phone number if you prefer to be contacted by phone')
 
     def summarise(self, field):

--- a/issues/tests/forms.py
+++ b/issues/tests/forms.py
@@ -101,7 +101,7 @@ class ProblemCreateFormTests(ProblemCreateFormBase, TestCase):
         del self.test_problem['reporter_phone']
         self.test_problem['preferred_contact_method'] = Problem.CONTACT_PHONE
         resp = self.client.post(self.form_url, self.test_problem)
-        self.assertFormError(resp, 'form', None, 'You must provide a phone number if you prefer to be contacted by phone')
+        self.assertFormError(resp, 'form', 'preferred_contact_method', 'You must provide a phone number if you prefer to be contacted by phone')
 
     def test_problem_form_accepts_email_only(self):
         del self.test_problem['reporter_phone']


### PR DESCRIPTION
In the problem form, you can add incorrect characters in the phone and email parts of the form. e.g. you can add letters in the phone box and an email address without an @ sign.

We need the form to reject the submission if these areas are not enetered correctly as it leaves the site vulnerable.

Tested on IE8, IE10, Firefox and Chrome.

In addition, if you tick the 'want to be contacted by phone box', we need to make the phone number box a mandatory field.
