### PR TITLE
Response confirmation page only links to Trust dashboards, when the user might be a CCG or superuser

### DIFF
--- a/responses/templates/responses/response-confirm.html
+++ b/responses/templates/responses/response-confirm.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load page_auth %}
 {% load url from future %}
 
 {% block title %}Response sent{% endblock %}
@@ -23,13 +24,20 @@
 
       {% if response %}
         <p><a href="{% url 'org-parent-dashboard' code=response.issue.organisation.parent.code %}">
-          Return to the '{{ response.issue.organisation.parent.name }}' dashboard
+          Go to the '{{ response.issue.organisation.parent.name }}' dashboard
         </a></p>
       {% elif issue %}
         <p><a href="{% url 'org-parent-dashboard' code=issue.organisation.parent.code %}">
-          Return to the '{{ response.issue.organisation.parent.name }}' dashboard
+          Go to the '{{ response.issue.organisation.parent.name }}' dashboard
         </a></p>
       {% endif %}
+
+      {% if user|is_ccg %}
+        {% for ccg in user.ccgs.all %}
+        <p><a href="{% url 'ccg-dashboard' code=ccg.code %}">Go to the '{{ ccg.name }}' dashboard</a></p>
+        {% endfor %}
+      {% endif %}
+      
 
     </div>
 </div>

--- a/responses/tests.py
+++ b/responses/tests.py
@@ -348,7 +348,7 @@ class ResponseFormViewTests(AuthorizationTestCase):
 
         # logout, login and get the form
         self.client.logout()
-        self.login_as(self.customer_contact_centre_user)
+        self.login_as(user_to_test_as)
         resp = self.client.get(self.response_form_url)
         self.assertEqual(resp.status_code, 200)
         
@@ -362,8 +362,14 @@ class ResponseFormViewTests(AuthorizationTestCase):
         # dashboard. This link should be appropriate to the type of user.
         # See #825 for details.
         
-        resp = self._change_user_and_submit(self.customer_contact_centre_user)
-        self.assertContains(resp, "Return to the '" + self.test_hospital.parent.name + "' dashboard") 
+        # only has one dashboard to return to
+        trust_resp = self._change_user_and_submit(self.trust_user)
+        self.assertContains(trust_resp, "Go to the '" + self.test_hospital.parent.name + "' dashboard") 
+
+        # also has the CCG dashboard
+        ccg_resp = self._change_user_and_submit(self.ccg_user)
+        self.assertContains(ccg_resp, "Go to the '" + self.test_hospital.parent.name + "' dashboard") 
+        self.assertContains(ccg_resp, "Go to the '" + self.test_ccg.name + "' dashboard") 
 
 
 class ResponseModelTests(TransactionTestCase, ConcurrencyTestMixin):


### PR DESCRIPTION
I think we need to do some more logic in the view when we build the context and produce the right link depending on who the user is.
