### PR TITLE
Images: confirm that images on moderation pages working

### DIFF
--- a/issues/templates/issues/includes/issue_meta_private.html
+++ b/issues/templates/issues/includes/issue_meta_private.html
@@ -24,35 +24,34 @@
 <div class="meta-data-wrap">
     <h3 class="meta-data-label">Images</h3>
     <div class="meta-data">
-        {% for image in object.images.all %}
+      {% with images=object.images.all %}
 
-          {% thumbnail item.image "x150" as im_small %}
-            {% thumbnail item.image "400x400" as im_large %}
-              <a
-                class="fancybox-zoom"
-                rel="problem-images"
-                href="{{ im_large.url }}"
-              ><img
-                src="{{ im_small.url }}"
-                height="{{ im_small.height }}"
-                width="{{ im_small.width }}"
-              /></a>
+        {% if images %}
+
+          {% for image in object.images.all %}
+
+            {% thumbnail image.image "x150" as im_small %}
+              {% thumbnail image.image "600x600" as im_large %}
+                <a
+                  class="fancybox-zoom"
+                  rel="problem-images"
+                  href="{{ im_large.url }}"
+                ><img
+                  src="{{ im_small.url }}"
+                  height="{{ im_small.height }}"
+                  width="{{ im_small.width }}"
+                /></a>
+              {% endthumbnail %}
             {% endthumbnail %}
-          {% endthumbnail %}
+          {% endfor %}
 
-          <p class="info">
-            {% with image_count=object.images.count %}
-              There are <strong>{{ image_count }}</strong>
-              images{{ image_count|pluralize }} associated with this problem
-              report.
-            {% endwith %}
-          </p>
-
-        {% empty %}
+        {% else %}
 
           There are no images attached to this report.
 
-        {% endfor %}
+        {% endif %}
+
+      {% endwith %}
     </div>
 
 </div>


### PR DESCRIPTION
Got my ordering wrong, so some code in #864 needed to be merged to master to continue on other tickets (the sorl stuff).

This ticket is here to remind us to go back and check that the images work as expected, which will be easier to do after #862 is done.
