### PR TITLE
Issues/927 show reporter contact details

### DIFF
--- a/issues/templates/issues/includes/issue_sidebar_private.html
+++ b/issues/templates/issues/includes/issue_sidebar_private.html
@@ -1,3 +1,5 @@
+{% load page_auth %}
+
 <div class="split-box  split-box--alert  split-box--alert--lrg">
     <div class="split-box__inner">
         {% if object.is_high_priority %}
@@ -71,6 +73,7 @@
     </div>
 </div>
 
+{% if user|may_see_reporter_contact_details %}
 <div class="meta-data-wrap">
     <h3 class="meta-data-label">Contact Details</h3>
     <div class="meta-data">
@@ -88,6 +91,7 @@
         </ul>
     </div>
 </div>
+{% endif %}
 
 <div class="meta-data-wrap">
     <h3 class="meta-data-label">Details</h3>

--- a/organisations/templatetags/page_auth.py
+++ b/organisations/templatetags/page_auth.py
@@ -3,7 +3,8 @@ register = template.Library()
 
 from .. import auth
 from ..auth import (user_is_escalation_body,
-                    user_in_group)
+                    user_in_group,
+                    user_is_superuser)
 
 
 @register.filter(is_safe=True)
@@ -22,3 +23,13 @@ def is_escalation_body(user):
     EG: a CCG or the CCC, and hence needs some links to their escalation
     """
     return user_is_escalation_body(user)
+
+
+@register.filter()
+def may_see_reporter_contact_details(user):
+    """
+    Returns true if the user may see the contact details of the reporter.
+    """
+
+    # currently limit to superusers until exact perms decided - see #873
+    return user_is_superuser(user)


### PR DESCRIPTION
Closes #927 

Adds a "contact details" box to the sidebar. Only shown to superusers atm, pending final permissions decision in #873 

![respond_to_a_problem](https://f.cloud.github.com/assets/187630/761347/e8edfb60-e7ce-11e2-9429-360196cec501.png)
