### PR TITLE
Images come before breach/escalation in tables

### DIFF
--- a/organisations/tables.py
+++ b/organisations/tables.py
@@ -280,7 +280,9 @@ class ProblemDashboardTable(BaseProblemTable):
                     'created',
                     'category',
                     'service',
-                    'summary')
+                    'summary',
+                    'images',
+                    'breach_and_escalation')
 
 
 class BreachTable(ProblemTable):


### PR DESCRIPTION
Not sure exactly how the breach/escalation columns looked in the tables before the images were introduced, but I've moved them to the end of the columns now:

![screen shot 2013-07-12 at 17 26 43](https://f.cloud.github.com/assets/22996/789388/e4183486-eb0f-11e2-9eeb-d2c3ba376bbe.png)

Closes #980 
