### PR TITLE
Re-open popups after filtering the map pins

### DIFF
--- a/web/js/map.js
+++ b/web/js/map.js
@@ -275,6 +275,8 @@ $(document).ready(function () {
             }
         });
 
+        // If there was already a popup open when the filtering occurred,
+        // check if the marker is still visible, if it is we reopen the popup.
         if (reopenPopup) {
             var odsCodes = _.pluck(providers, 'ods_code')
             var reopenCode = reopenPopup._source.nhsCentre.ods_code;


### PR DESCRIPTION
Keeps track of the currently open popup and attempts to re-open it after filtering the map. Perhaps a little fragile as it uses the private `_source` property on the popup, but sadly I can't find a nicer solution.

Closes #854 
