### PR TITLE
Make keep private button mark things as private

### DIFF
--- a/moderation/tests/forms.py
+++ b/moderation/tests/forms.py
@@ -56,7 +56,7 @@ class ModerationFormPublicReporterNameMixin(object):
             'public_reporter_name': True,
             'requires_second_tier_moderation': True,
         })
-        
+
         self.private_name_problem = create_test_problem({
             'organisation':self.test_hospital,
             'public_reporter_name': False,
@@ -146,7 +146,7 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
             'moderated_description': moderated_description
         }
         self.form_values.update(test_form_values)
-        resp = self.client.post(self.problem_form_url, self.form_values)
+        self.client.post(self.problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_problem.id)
         self.assertEqual(problem.moderated_description, moderated_description)
 
@@ -155,7 +155,7 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
             'breach': 1
         }
         self.form_values.update(test_form_values)
-        resp = self.client.post(self.problem_form_url, self.form_values)
+        self.client.post(self.problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_problem.id)
         self.assertEqual(problem.breach, True)
 
@@ -164,7 +164,7 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
             'status': Problem.ESCALATED
         }
         self.form_values.update(test_form_values)
-        resp = self.client.post(self.problem_form_url, self.form_values)
+        self.client.post(self.problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_problem.id)
         self.assertEqual(problem.status, Problem.NEW)
 
@@ -173,7 +173,7 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
             'status': Problem.REFERRED_TO_OTHER_PROVIDER
         }
         self.form_values.update(test_form_values)
-        resp = self.client.post(self.problem_form_url, self.form_values)
+        self.client.post(self.problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_problem.id)
         self.assertEqual(problem.status, Problem.REFERRED_TO_OTHER_PROVIDER)
 
@@ -183,23 +183,12 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
                                                 self.problem_form_url,
                                                 self.test_problem)
 
-    def test_moderation_form_sets_publication_status_to_private_when_keep_private_clicked(self):
-        test_form_values = {
-            'keep_private': ''
-        }
-        self.form_values.update(test_form_values)
-        del self.form_values['publish']
-        self.assert_expected_publication_status(Problem.REJECTED,
-                                                self.form_values,
-                                                self.problem_form_url,
-                                                self.test_problem)
-
     def test_moderation_form_sets_publication_status_to_not_moderated_when_requires_second_tier_moderation_clicked(self):
 
         # Change the problem to PUBLISHED so we can test that a change occurs.
         self.test_problem.publication_status = Problem.PUBLISHED
         self.test_problem.save()
-        self.client.get(self.problem_form_url) # deal with versioning
+        self.client.get(self.problem_form_url)  # deal with versioning
 
         # change the submit button that'll be used
         self.form_values['now_requires_second_tier_moderation'] = ''
@@ -209,6 +198,52 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
                                                 self.form_values,
                                                 self.problem_form_url,
                                                 self.test_problem)
+
+    def test_moderation_form_sets_publication_status_to_published_when_keep_private_clicked(self):
+        # change the submit button that'll be used
+        test_form_values = {
+            'keep_private': ''
+        }
+        self.form_values.update(test_form_values)
+        del self.form_values['publish']
+
+        self.assert_expected_publication_status(Problem.PUBLISHED,
+                                                self.form_values,
+                                                self.problem_form_url,
+                                                self.test_problem)
+
+    def test_moderation_form_sets_public_to_false_when_keep_private_clicked(self):
+        # Make sure the problem is public
+        self.test_problem.public = True
+        self.test_problem.save()
+        self.client.get(self.problem_form_url)  # deal with versioning
+
+        test_form_values = {
+            'keep_private': ''
+        }
+        self.form_values.update(test_form_values)
+        del self.form_values['publish']
+
+        self.client.post(self.problem_form_url, self.form_values)
+
+        problem = Problem.objects.get(pk=self.test_problem.id)
+        self.assertFalse(problem.public)
+
+    def test_moderation_form_doesnt_allow_setting_of_public_otherwise(self):
+        # Make sure the problem is not public
+        self.test_problem.public = False
+        self.test_problem.save()
+        self.client.get(self.problem_form_url)  # deal with versioning
+
+        test_form_values = {
+            'public': True
+        }
+        self.form_values.update(test_form_values)
+
+        self.client.post(self.problem_form_url, self.form_values)
+
+        problem = Problem.objects.get(pk=self.test_problem.id)
+        self.assertFalse(problem.public)
 
     def assert_expected_requires_second_tier_moderation(self, expected_value, form_values):
         resp = self.client.post(self.problem_form_url, form_values)
@@ -258,8 +293,7 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
         resp = self.client.post(self.problem_form_url, self.form_values)
         self.assertFormError(resp, 'form', 'moderated_description', 'You must moderate a version of the problem details when publishing public problems.')
 
-
-    def test_moderation_form_doesnt_requires_moderated_description_for_private_problems(self):
+    def test_moderation_form_doesnt_require_moderated_description_for_private_problems(self):
         # make the problem private
         self.test_problem.public = False
         self.test_problem.save()
@@ -285,18 +319,18 @@ class ModerationFormTests(ModerationFormPublicReporterNameMixin, BaseModerationT
         self.assertEqual(problem.moderated_description, '')
         self.assertEqual(problem.publication_status, Problem.PUBLISHED)
 
-
     def test_moderation_form_doesnt_require_moderated_description_when_hiding_problems(self):
-        expected_status = Problem.REJECTED
         test_form_values = {
             'keep_private': ''
         }
         self.form_values.update(test_form_values)
         del self.form_values['publish']
         del self.form_values['moderated_description']
-        resp = self.client.post(self.problem_form_url, self.form_values)
+
+        self.client.post(self.problem_form_url, self.form_values)
+
         problem = Problem.objects.get(pk=self.test_problem.id)
-        self.assertEqual(problem.publication_status, expected_status)
+        self.assertFalse(problem.public)
 
     def test_moderation_form_can_moderate_responses(self):
         # Add some responses to the test problem
@@ -451,7 +485,7 @@ class SecondTierModerationFormTests(ModerationFormPublicReporterNameMixin, BaseM
         self.assertContains(resp, self.second_tier_home_url)
 
     def test_second_tier_moderation_form_sets_requires_second_tier_moderation_to_false(self):
-        resp = self.client.post(self.second_tier_problem_form_url, self.form_values)
+        self.client.post(self.second_tier_problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_second_tier_moderation_problem.id)
         self.assertEqual(problem.requires_second_tier_moderation, False)
 
@@ -484,16 +518,15 @@ class SecondTierModerationFormTests(ModerationFormPublicReporterNameMixin, BaseM
         self.assertEqual(problem.publication_status, expected_status)
 
     def test_second_tier_moderation_form_doesnt_require_moderated_description_when_hiding_problems(self):
-        expected_status = Problem.REJECTED
         test_form_values = {
             'keep_private': ''
         }
         self.form_values.update(test_form_values)
         del self.form_values['publish']
         del self.form_values['moderated_description']
-        resp = self.client.post(self.second_tier_problem_form_url, self.form_values)
+        self.client.post(self.second_tier_problem_form_url, self.form_values)
         problem = Problem.objects.get(pk=self.test_second_tier_moderation_problem.id)
-        self.assertEqual(problem.publication_status, expected_status)
+        self.assertFalse(problem.public)
 
     def test_second_tier_moderation_form_sets_publication_status_to_published_when_publish_clicked(self):
         self.assert_expected_publication_status(Problem.PUBLISHED,
@@ -501,16 +534,39 @@ class SecondTierModerationFormTests(ModerationFormPublicReporterNameMixin, BaseM
                                                 self.second_tier_problem_form_url,
                                                 self.test_second_tier_moderation_problem)
 
-    def test_second_tier_moderation_form_sets_publication_status_to_private_when_keep_private_clicked(self):
+    def test_second_tier_moderation_form_sets_public_to_false_when_keep_private_clicked(self):
+        # Make sure the problem is public
+        self.test_second_tier_moderation_problem.public = True
+        self.test_second_tier_moderation_problem.save()
+        self.client.get(self.second_tier_problem_form_url)
+
         test_form_values = {
             'keep_private': ''
         }
         self.form_values.update(test_form_values)
         del self.form_values['publish']
-        self.assert_expected_publication_status(Problem.REJECTED,
-                                                self.form_values,
-                                                self.second_tier_problem_form_url,
-                                                self.test_second_tier_moderation_problem)
+
+        self.client.post(self.second_tier_problem_form_url, self.form_values)
+
+        problem = Problem.objects.get(pk=self.test_second_tier_moderation_problem.id)
+        self.assertFalse(problem.public)
+
+    def test_second_tier_moderation_form_doesnt_allow_setting_of_public_otherwise(self):
+        # Make sure the problem is not public
+        self.test_second_tier_moderation_problem.public = False
+        self.test_second_tier_moderation_problem.save()
+        self.client.get(self.second_tier_problem_form_url)  # deal with versioning
+
+        test_form_values = {
+            'public': True
+        }
+        self.form_values.update(test_form_values)
+
+        self.client.post(self.second_tier_problem_form_url, self.form_values)
+
+        problem = Problem.objects.get(pk=self.test_second_tier_moderation_problem.id)
+        self.assertFalse(problem.public)
+
 
 class SecondTierModerationFormConcurrencyTests(BaseModerationTestCase):
 


### PR DESCRIPTION
Closes #1031

Note. This offers no way to make something public again, so if you mistakenly mark something as private, it's impossible to make it public again in either moderation form.

I think this is for the best (it's complicated otherwise, and people could accidentally mark something as public which they didn't mean to, which is much worse)
