### PR TITLE
Pass --system-site-packages to virtualenv if >= 1.7

### DIFF
--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -10,7 +10,14 @@ cd `dirname $0`/..
 # NOTE: some packages are difficult to install if they are not site packages,
 # for example xapian. If using these you might want to add the
 # '--enable-site-packages' argument.
-virtualenv --no-site-packages ../virtualenv-citizenconnect
+virtualenv_version="$(virtualenv --version)"
+if [ "$(echo -e '1.7\n'$virtualenv_version | sort -V | head -1)" = '1.7' ]; then
+    virtualenv_args="--system-site-packages"
+else
+    virtualenv_args="--no-site-packages"
+fi 
+
+virtualenv $virtualenv_args ../virtualenv-citizenconnect
 source ../virtualenv-citizenconnect/bin/activate
 pip install --requirement requirements.txt
 


### PR DESCRIPTION
This is needed to get tests to run cleanly on Debian wheezy -- it forces virtualenv to use the installed PIL (Debian package `python-imaging`) rather than attempting to build our own (which fails).
