### PR TITLE
Pin all packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,48 +1,35 @@
-# List all Python package requirements this project has.
-#
-# more details: http://www.pip-installer.org/en/latest/requirements.html
-
-### General useful bits
-ordereddict
-PyYAML
-psycopg2
-uk-postcode-utils
-requests==1.2.0
-furl
-python-dateutil
-pytz
-lxml==3.2.1
-PIL
-feedparser==5.1.3
-
-### Django related
 Django==1.4.5
+PIL==1.1.7
+PyYAML==3.10
 South==0.8.1
-django-pagination
-django-tables2
-django-reversion==1.6.6  # compatible with Django 1.4.5
-django-concurrency
-django-passwords
+argparse==1.2.1
+distribute==0.6.24
+django-concurrency==0.5
+django-dirtyfields==0.1
+django-extensions==1.2.0
 django-extra-views==0.6.3
-sorl-thumbnail
-django-pipeline==1.3.13
 django-failedloginblocker==1.0.1
 django-os-geocoder==0.1.6
-
-### Testing
-mock
-selenium
-
-### Django related registration
-# The registration app is a little out of date - get it from the repo direct....
-# django-registration
-# -e hg+https://bitbucket.org/ubernostrum/django-registration@fad7080fe769#egg=django-registration
-# django-registration-defaults
-
-### Xapian is a full text search engine, and haystack a django interface to it.
-### If you want to use this uncomment below, and probably add the
-### '--enable-site-packages' argument to the pip install command in
-### 'post_deploy_actions.bash'
-# xapian-haystack
-# django-haystack
-
+django-pagination==1.0.7
+django-passwords==0.2.0
+django-pipeline==1.3.13
+django-reversion==1.6.6
+django-tables2==0.13.0
+feedparser==5.1.3
+furl==0.3.4
+futures==2.1.4
+ipython==1.0.0
+lxml==3.2.1
+mock==1.0.1
+ordereddict==1.1
+orderedmultidict==0.7.1
+progressbar==2.3
+psycopg2==2.5.1
+python-dateutil==2.1
+pytz==2013d
+requests==1.2.0
+selenium==2.35.0
+six==1.3.0
+sorl-thumbnail==11.12
+uk-postcode-utils==0.1.0
+wsgiref==0.1.2


### PR DESCRIPTION
I've basically double checked every version of things that I have, then done a pip freeze > requirements.txt because that seemed like the easiest way to do this going forward.

This has picked up some extra packages from dependencies of dependencies, and also added in django-extensions and ipython which I had locally. Both of these are helpful, even on production, so I've left them in.

From now on, if you add or change python modules, you should do it locally via `pip install` etc, and then `pip freeze > requirements.txt` to commit it.

Closes #1164
